### PR TITLE
[G7T5-52] Create courses REST endpoint unit tests

### DIFF
--- a/backend/app/api/api_v1/endpoints/course.py
+++ b/backend/app/api/api_v1/endpoints/course.py
@@ -18,6 +18,11 @@ def get_all_course(
     Retrieve all courses.
     """
     courses = crud.course.get_multi(db, skip=skip)
+    if not courses:
+        raise HTTPException(
+            status_code=404,
+            detail="Courses not found",
+        )
     return courses
 
 
@@ -30,6 +35,11 @@ def get_course_by_id(
     Get a specific course by id.
     """
     course = crud.course.get(db, course_id=course_id)
+    if not course:
+        raise HTTPException(
+            status_code=404,
+            detail="Course not found",
+        )
     return course
 
 
@@ -100,7 +110,7 @@ def update_course_by_id(
 def delete_course_by_id(
     *,
     db: Session = Depends(deps.get_db),
-    course_id: int,
+    course_id: str,
 ) -> Any:
     """
     Delete a course.

--- a/backend/app/tests/api/api_v1/test_course.py
+++ b/backend/app/tests/api/api_v1/test_course.py
@@ -1,0 +1,147 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.tests.utils.course import COURSE_ID_LENGTH, create_random_course
+from app.tests.utils.utils import random_lower_string
+
+
+def test_get_all_courses_non_existent(client: TestClient, db: Session) -> None:
+    response = client.get(
+        f"{settings.API_V1_STR}/course/all",
+    )
+    assert response.status_code == 404
+    content = response.json()
+    assert content["detail"] == "Courses not found"
+
+
+def test_get_course_by_id(client: TestClient, db: Session) -> None:
+    course = create_random_course(db)
+    response = client.get(
+        f"{settings.API_V1_STR}/course/{course.course_id}",
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["course_id"] == course.course_id
+    assert content["course_name"] == course.course_name
+    assert content["course_desc"] == course.course_desc
+    assert content["course_status"] == course.course_status
+    assert content["course_type"] == course.course_type
+    assert content["course_category"] == course.course_category
+
+
+def test_get_course_by_id_non_existent(client: TestClient, db: Session) -> None:
+    response = client.get(
+        f"{settings.API_V1_STR}/course/{random_lower_string(COURSE_ID_LENGTH)}",
+    )
+    assert response.status_code == 404
+    content = response.json()
+    assert content["detail"] == "Course not found"
+
+
+def test_get_all_courses(client: TestClient, db: Session) -> None:
+    course = create_random_course(db)
+    response = client.get(
+        f"{settings.API_V1_STR}/course/all",
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert len(content) == 2
+
+    is_course_in_response = False
+    for obj in content:
+        if obj["course_id"] == course.course_id:
+            assert obj["course_name"] == course.course_name
+            assert obj["course_desc"] == course.course_desc
+            assert obj["course_status"] == course.course_status
+            assert obj["course_type"] == course.course_type
+            assert obj["course_category"] == course.course_category
+            is_course_in_response = True
+            break
+    assert is_course_in_response
+
+
+def test_create_course_minimum_fields(client: TestClient, db: Session) -> None:
+    data = {"course_id": "CSR111", "course_name": "Foo"}
+    response = client.post(
+        f"{settings.API_V1_STR}/course",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["course_id"] == data["course_id"]
+    assert content["course_name"] == data["course_name"]
+
+
+def test_create_course_all_fields(client: TestClient, db: Session) -> None:
+    data = {
+        "course_id": "CSR112",
+        "course_name": "Chilli",
+        "course_desc": "Lorem ipsum",
+        "course_status": "Active",
+        "course_type": "Internal",
+        "course_category": "Technical",
+    }
+    response = client.post(
+        f"{settings.API_V1_STR}/course",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["course_id"] == data["course_id"]
+    assert content["course_name"] == data["course_name"]
+    assert content["course_desc"] == data["course_desc"]
+    assert content["course_status"] == data["course_status"]
+    assert content["course_type"] == data["course_type"]
+    assert content["course_category"] == data["course_category"]
+
+
+def test_update_course_by_id(client: TestClient, db: Session) -> None:
+    course = create_random_course(db)
+    data = {"course_name": "Bar"}
+    assert course.course_name != data["course_name"]
+    response = client.put(
+        f"{settings.API_V1_STR}/course/{course.course_id}",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["course_id"] == course.course_id
+    assert content["course_name"] == data["course_name"]
+    assert content["course_desc"] == course.course_desc
+    assert content["course_status"] == course.course_status
+    assert content["course_type"] == course.course_type
+    assert content["course_category"] == course.course_category
+
+
+def test_update_course_by_id_non_existent(client: TestClient, db: Session) -> None:
+    data = {"course_name": "Bar"}
+    response = client.put(
+        f"{settings.API_V1_STR}/course/{random_lower_string(COURSE_ID_LENGTH)}",
+        json=data,
+    )
+    assert response.status_code == 404
+    content = response.json()
+    assert content["detail"] == "Course not found"
+
+
+def test_delete_course_by_id(client: TestClient, db: Session) -> None:
+    course = create_random_course(db)
+    response = client.delete(f"{settings.API_V1_STR}/course/{course.course_id}")
+    assert response.status_code == 200
+    content = response.json()
+    assert content["course_id"] == course.course_id
+    assert content["course_name"] == course.course_name
+    assert content["course_desc"] == course.course_desc
+    assert content["course_status"] == course.course_status
+    assert content["course_type"] == course.course_type
+    assert content["course_category"] == course.course_category
+
+
+def test_delete_course_by_id_non_existent(client: TestClient, db: Session) -> None:
+    response = client.delete(
+        f"{settings.API_V1_STR}/course/{random_lower_string(COURSE_ID_LENGTH)}"
+    )
+    assert response.status_code == 404
+    content = response.json()
+    assert content["detail"] == "Course not found"

--- a/backend/app/tests/crud/test_course.py
+++ b/backend/app/tests/crud/test_course.py
@@ -1,0 +1,101 @@
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.schemas.course import CourseCreate, CourseUpdate
+from app.tests.utils.course import (
+    COURSE_CATEGORY_LENGTH,
+    COURSE_DESC_LENGTH,
+    COURSE_ID_LENGTH,
+    COURSE_NAME_LENGTH,
+    COURSE_STATUS_LENGTH,
+    COURSE_TYPE_LENGTH,
+    create_random_course,
+)
+from app.tests.utils.utils import random_lower_string
+
+
+def test_create_course(db: Session) -> None:
+    course_id = random_lower_string(COURSE_ID_LENGTH)
+    course_name = random_lower_string(COURSE_NAME_LENGTH)
+    course_desc = random_lower_string(COURSE_DESC_LENGTH)
+    course_status = random_lower_string(COURSE_STATUS_LENGTH)
+    course_type = random_lower_string(COURSE_TYPE_LENGTH)
+    course_category = random_lower_string(COURSE_CATEGORY_LENGTH)
+    course_in = CourseCreate(
+        course_id=course_id,
+        course_name=course_name,
+        course_desc=course_desc,
+        course_status=course_status,
+        course_type=course_type,
+        course_category=course_category,
+    )
+    course = crud.course.create(
+        db=db,
+        obj_in=course_in,
+    )
+    assert course.course_id == course_id
+    assert course.course_name == course_name
+    assert course.course_desc == course_desc
+    assert course.course_status == course_status
+    assert course.course_type == course_type
+    assert course.course_category == course_category
+
+
+def test_create_course_minimum_fields(db: Session) -> None:
+    course_id = random_lower_string(COURSE_ID_LENGTH)
+    course_name = random_lower_string(COURSE_NAME_LENGTH)
+    course_in = CourseCreate(
+        course_id=course_id,
+        course_name=course_name,
+    )
+    course = crud.course.create(
+        db=db,
+        obj_in=course_in,
+    )
+    assert course.course_id == course_id
+    assert course.course_name == course_name
+    assert course.course_desc == None
+    assert course.course_status == None
+    assert course.course_type == None
+    assert course.course_category == None
+
+
+def test_get_course(db: Session) -> None:
+    course = create_random_course(db)
+    stored_course = crud.course.get(db=db, course_id=course.course_id)
+    assert stored_course
+    assert course.course_id == stored_course.course_id
+    assert course.course_name == stored_course.course_name
+    assert course.course_desc == stored_course.course_desc
+    assert course.course_status == stored_course.course_status
+    assert course.course_type == stored_course.course_type
+    assert course.course_category == stored_course.course_category
+
+
+def test_update_course(db: Session) -> None:
+    course = create_random_course(db)
+    new_course_name = random_lower_string(COURSE_NAME_LENGTH)
+    assert new_course_name != course.course_name
+    course_update = CourseUpdate(
+        course_id=course.course_id, course_name=new_course_name
+    )
+    course2 = crud.course.update(db=db, db_obj=course, obj_in=course_update)
+    assert course2.course_id == course.course_id
+    assert course2.course_name == new_course_name
+    assert course2.course_desc == course.course_desc
+    assert course2.course_status == course.course_status
+    assert course2.course_type == course.course_type
+    assert course2.course_category == course.course_category
+
+
+def test_delete_course(db: Session) -> None:
+    course = create_random_course(db)
+    course2 = crud.course.remove(db=db, course_id=course.course_id)
+    course3 = crud.course.get(db=db, course_id=course.course_id)
+    assert course3 is None
+    assert course2.course_id == course.course_id
+    assert course2.course_name == course.course_name
+    assert course2.course_desc == course.course_desc
+    assert course2.course_status == course.course_status
+    assert course2.course_type == course.course_type
+    assert course2.course_category == course.course_category

--- a/backend/app/tests/utils/course.py
+++ b/backend/app/tests/utils/course.py
@@ -1,0 +1,30 @@
+from sqlalchemy.orm import Session
+
+from app import crud, models
+from app.schemas.course import CourseCreate
+from app.tests.utils.utils import random_lower_string
+
+COURSE_ID_LENGTH = 20
+COURSE_NAME_LENGTH = 50
+COURSE_DESC_LENGTH = 255
+COURSE_STATUS_LENGTH = 15
+COURSE_TYPE_LENGTH = 10
+COURSE_CATEGORY_LENGTH = 50
+
+
+def create_random_course(db: Session) -> models.Course:
+    course_id = random_lower_string(COURSE_ID_LENGTH)
+    course_name = random_lower_string(COURSE_NAME_LENGTH)
+    course_desc = random_lower_string(COURSE_DESC_LENGTH)
+    course_status = random_lower_string(COURSE_STATUS_LENGTH)
+    course_type = random_lower_string(COURSE_TYPE_LENGTH)
+    course_category = random_lower_string(COURSE_CATEGORY_LENGTH)
+    course_in = CourseCreate(
+        course_id=course_id,
+        course_name=course_name,
+        course_desc=course_desc,
+        course_status=course_status,
+        course_type=course_type,
+        course_category=course_category,
+    )
+    return crud.course.create(db=db, obj_in=course_in)


### PR DESCRIPTION
# Description

To populate the information of courses in the frontend, we need REST endpoints to support the CRUD actions necessary. While the endpoints have been implemented [previously](https://github.com/is212g7t5/spm/pull/1), these implementations were not unit tested. This PR refines some of the CRUD operations and adds unit tests for courses.

Fixes https://is212g7t5.atlassian.net/browse/G7T5-52

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
