### PR TITLE
[G7T5-97] Add validation for job create and update

### DIFF
--- a/backend/alembic/versions/0006_alter_job_table.py
+++ b/backend/alembic/versions/0006_alter_job_table.py
@@ -1,0 +1,35 @@
+"""Alter job Table
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2022-10-02 00:00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+UPGRADE_SQL = """
+ALTER TABLE job
+ADD INDEX `index_job_name` (job_name),
+MODIFY job_desc varchar(255) NOT NULL;
+"""
+
+DOWNGRADE_SQL = """
+ALTER TABLE job
+MODIFY job_desc varchar(255) DEFAULT NULL,
+DROP INDEX `index_job_name`;
+"""
+
+
+def upgrade():
+    op.execute(UPGRADE_SQL)
+
+
+def downgrade():
+    op.execute(DOWNGRADE_SQL)

--- a/backend/alembic/versions/0007_alter_job_table.py
+++ b/backend/alembic/versions/0007_alter_job_table.py
@@ -1,15 +1,15 @@
 """Alter job Table
 
-Revision ID: 0006
-Revises: 0005
+Revision ID: 0007
+Revises: 0006
 Create Date: 2022-10-02 00:00:00
 
 """
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "0006"
-down_revision = "0005"
+revision = "0007"
+down_revision = "0006"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/crud/crud_job.py
+++ b/backend/app/crud/crud_job.py
@@ -11,11 +11,13 @@ class CRUDJob(CRUDBase[Job, JobCreate, JobUpdate]):
     def get(self, db: Session, job_id: Any) -> Job:
         return db.query(self.model).filter(self.model.job_id == job_id).first()
 
+    def get_by_job_name(self, db: Session, job_name: Any) -> Job:
+        return db.query(self.model).filter(self.model.job_name == job_name).first()
+
     def create(self, db: Session, *, obj_in: JobCreate) -> Job:
         db_obj = Job(
             job_name=obj_in.job_name,
             job_desc=obj_in.job_desc,
-            is_active=obj_in.is_active,
         )
         db.add(db_obj)
         db.commit()

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -1,14 +1,27 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 
 # Shared properties
 class JobBase(BaseModel):
-    job_id: Optional[int]
     job_name: str
-    job_desc: Optional[str]
-    is_active: bool
+    job_desc: str
+
+    @validator("job_name")
+    @classmethod
+    def validate_job_name(cls, job_name):
+        job_name = job_name.strip()
+        assert len(job_name) >= 1, "job_name must minimally be 1 character long"
+        assert len(job_name) <= 50, "job_name cannot exceed 50 characters"
+        return job_name
+
+    @validator("job_desc")
+    @classmethod
+    def validate_job_desc(cls, job_desc):
+        assert len(job_desc) >= 1, "job_desc must minimally be 1 character long"
+        assert len(job_desc) <= 255, "job_desc cannot exceed 255 characters"
+        return job_desc
 
 
 # Properties to receive via API on creation
@@ -18,11 +31,14 @@ class JobCreate(JobBase):
 
 # Properties to receive via API on update
 class JobUpdate(JobBase):
-    pass
+    job_name: Optional[str] = None
+    job_desc: Optional[str] = None
+    is_active: Optional[bool] = None
 
 
 class JobInDBBase(JobBase):
     job_id: Optional[int] = None
+    is_active: bool = True
 
     class Config:
         orm_mode = True

--- a/backend/app/tests/api/api_v1/test_job.py
+++ b/backend/app/tests/api/api_v1/test_job.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.tests.utils.job import create_random_job
 from app.tests.utils.job_skill import add_skill_to_job, create_random_job_skill
+from app.tests.utils.utils import random_lower_string
 
 
 def test_get_all_jobs_non_existent(client: TestClient, db: Session) -> None:
@@ -110,8 +111,6 @@ def test_get_all_jobs_and_skills_one_job_many_skills(
     assert len(response.json()) == 6
 
     content = response.json()
-    print(content)
-    print([dir(x) for x in extra_skills])
 
     job_skill_in_response = 0
     for obj in content:
@@ -130,8 +129,8 @@ def test_get_all_jobs_and_skills_one_job_many_skills(
     assert job_skill_in_response == 3
 
 
-def test_create_job_no_desc(client: TestClient, db: Session) -> None:
-    data = {"job_name": "Foo", "job_desc": None}
+def test_create_job_short_job_name_pass(client: TestClient, db: Session) -> None:
+    data = {"job_name": random_lower_string(1), "job_desc": "Bar"}
     response = client.post(
         f"{settings.API_V1_STR}/job",
         json=data,
@@ -144,8 +143,131 @@ def test_create_job_no_desc(client: TestClient, db: Session) -> None:
     assert "job_id" in content
 
 
+def test_create_job_short_job_name_fail(client: TestClient, db: Session) -> None:
+    data = {"job_name": "", "job_desc": "Bar"}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 422
+    content = response.json()
+    assert content["detail"][0]["msg"] == "job_name must minimally be 1 character long"
+
+
+def test_create_job_long_job_name_pass(client: TestClient, db: Session) -> None:
+    data = {"job_name": random_lower_string(50), "job_desc": "Bar"}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_name"] == data["job_name"]
+    assert content["job_desc"] == data["job_desc"]
+    assert content["is_active"] == True
+    assert "job_id" in content
+
+
+def test_create_job_long_job_name_fail(client: TestClient, db: Session) -> None:
+    data = {"job_name": random_lower_string(51), "job_desc": "Bar"}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 422
+    content = response.json()
+    assert content["detail"][0]["msg"] == "job_name cannot exceed 50 characters"
+
+
+def test_create_job_duplicate_job_name(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_name": job.job_name, "job_desc": "Bar"}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 409
+    content = response.json()
+    assert content["detail"] == "job_name already exists"
+
+
+def test_create_job_white_space_job_name(client: TestClient, db: Session) -> None:
+    job_name = random_lower_string(50)
+    white_space_job_name = " " * 50 + job_name + " " * 50
+    data = {"job_name": white_space_job_name, "job_desc": "Bar"}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_name"] == job_name
+    assert content["job_desc"] == data["job_desc"]
+    assert content["is_active"] == True
+    assert "job_id" in content
+
+
+def test_create_job_no_desc(client: TestClient, db: Session) -> None:
+    data = {"job_name": "Foo", "job_desc": None}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 422
+
+
+def test_create_job_short_desc_pass(client: TestClient, db: Session) -> None:
+    data = {"job_name": "Moo", "job_desc": random_lower_string(1)}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_name"] == data["job_name"]
+    assert content["job_desc"] == data["job_desc"]
+    assert content["is_active"] == True
+    assert "job_id" in content
+
+
+def test_create_job_short_desc_fail(client: TestClient, db: Session) -> None:
+    data = {"job_name": "Boo", "job_desc": ""}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 422
+    content = response.json()
+    assert content["detail"][0]["msg"] == "job_desc must minimally be 1 character long"
+
+
+def test_create_job_long_desc_pass(client: TestClient, db: Session) -> None:
+    data = {"job_name": "Meow", "job_desc": random_lower_string(255)}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_name"] == data["job_name"]
+    assert content["job_desc"] == data["job_desc"]
+    assert content["is_active"] == True
+    assert "job_id" in content
+
+
+def test_create_job_long_desc_fail(client: TestClient, db: Session) -> None:
+    data = {"job_name": "Crow", "job_desc": random_lower_string(256)}
+    response = client.post(
+        f"{settings.API_V1_STR}/job",
+        json=data,
+    )
+    assert response.status_code == 422
+    content = response.json()
+    assert content["detail"][0]["msg"] == "job_desc cannot exceed 255 characters"
+
+
 def test_create_job_with_desc(client: TestClient, db: Session) -> None:
-    data = {"job_name": "Foo", "job_desc": "Bar"}
+    data = {"job_name": "Cow", "job_desc": "Bar"}
     response = client.post(
         f"{settings.API_V1_STR}/job",
         json=data,
@@ -183,6 +305,145 @@ def test_update_job_by_id_non_existent(client: TestClient, db: Session) -> None:
     assert response.status_code == 404
     content = response.json()
     assert content["detail"] == "Job not found"
+
+
+def test_update_job_short_job_name_pass(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_name": random_lower_string(1)}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_id"] == job.job_id
+    assert content["job_desc"] == job.job_desc
+    assert content["is_active"] == job.is_active
+    assert content["job_name"] == data["job_name"]
+
+
+def test_update_job_short_job_name_fail(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_name": ""}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 422
+    content = response.json()
+    assert content["detail"][0]["msg"] == "job_name must minimally be 1 character long"
+
+
+def test_update_job_long_job_name_pass(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_name": random_lower_string(50)}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_id"] == job.job_id
+    assert content["job_desc"] == job.job_desc
+    assert content["is_active"] == job.is_active
+    assert content["job_name"] == data["job_name"]
+
+
+def test_update_job_long_job_name_fail(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_name": random_lower_string(51)}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 422
+    content = response.json()
+    assert content["detail"][0]["msg"] == "job_name cannot exceed 50 characters"
+
+
+def test_update_job_duplicate_job_name(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    existing_job_name = create_random_job(db).job_name
+    data = {"job_name": existing_job_name}
+    assert job.job_name != existing_job_name
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 409
+    content = response.json()
+    assert content["detail"] == "job_name already exists"
+
+
+def test_update_job_white_space_job_name(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    job_name = random_lower_string(50)
+    white_space_job_name = " " * 50 + job_name + " " * 50
+    data = {"job_name": white_space_job_name}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_id"] == job.job_id
+    assert content["job_desc"] == job.job_desc
+    assert content["is_active"] == job.is_active
+    assert content["job_name"] == job_name
+
+
+def test_update_job_short_job_desc_pass(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_desc": "a"}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_id"] == job.job_id
+    assert content["job_name"] == job.job_name
+    assert content["is_active"] == job.is_active
+    assert content["job_desc"] == data["job_desc"]
+
+
+def test_update_job_short_job_desc_fail(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_desc": ""}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 422
+    content = response.json()
+    assert content["detail"][0]["msg"] == "job_desc must minimally be 1 character long"
+
+
+def test_update_job_long_job_desc_pass(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_desc": random_lower_string(255)}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_id"] == job.job_id
+    assert content["job_name"] == job.job_name
+    assert content["is_active"] == job.is_active
+    assert content["job_desc"] == data["job_desc"]
+
+
+def test_update_job_long_job_desc_fail(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_desc": random_lower_string(256)}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 422
+    content = response.json()
+    assert content["detail"][0]["msg"] == "job_desc cannot exceed 255 characters"
 
 
 def test_delete_job_by_id(client: TestClient, db: Session) -> None:

--- a/backend/app/tests/crud/test_job.py
+++ b/backend/app/tests/crud/test_job.py
@@ -31,9 +31,7 @@ def test_update_job(db: Session) -> None:
     job = create_random_job(db)
     new_job_name = random_lower_string(20)
     assert new_job_name != job.job_name
-    job_update = JobUpdate(
-        job_name=new_job_name, job_desc=job.job_desc, is_active=job.is_active
-    )
+    job_update = JobUpdate(job_name=new_job_name)
     job2 = crud.job.update(db=db, db_obj=job, obj_in=job_update)
     assert job2.job_id == job.job_id
     assert job2.job_desc == job.job_desc

--- a/backend/app/tests/utils/job.py
+++ b/backend/app/tests/utils/job.py
@@ -11,5 +11,5 @@ JOB_DESC_LENGTH = 255
 def create_random_job(db: Session) -> models.Job:
     job_name = random_lower_string(JOB_NAME_LENGTH)
     job_desc = random_lower_string(JOB_DESC_LENGTH)
-    job_in = JobCreate(job_name=job_name, job_desc=job_desc, is_active=True)
+    job_in = JobCreate(job_name=job_name, job_desc=job_desc)
     return crud.job.create(db=db, obj_in=job_in)


### PR DESCRIPTION
# Description
Introduces field validation for Job
- `job_name` length must be 1-50
- `job_desc` length must be 1-255 (and is now a compulsory field)

<!-- Please add link to Jira Ticket here -->
Fixes [Jira ticket G7T5-97](https://is212g7t5.atlassian.net/browse/G7T5-97)
<!-- Add Screenshots if there are changes or additions in frontend components -->
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

- [x] G7T5-1-1
- [x] G7T5-1-2
- [x] G7T5-1-3
- [x] G7T5-1-4
- [x] G7T5-1-5
- [x] G7T5-1-6
- [x] G7T5-1-7
- [x] G7T5-1-8
- [x] G7T5-1-9
- [x] G7T5-1-10
- [x] G7T5-1-11

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
