### PR TITLE
[G7T5-100] Add get active skills to /skills/all endpoint

### DIFF
--- a/backend/app/api/api_v1/endpoints/skill.py
+++ b/backend/app/api/api_v1/endpoints/skill.py
@@ -14,11 +14,12 @@ router = APIRouter()
 def get_all_skill(
     db: Session = Depends(deps.get_db),
     skip: int = 0,
+    active_only: bool = False,
 ) -> Any:
     """
     Retrieve all skills.
     """
-    skills = crud.skill.get_multi(db, skip=skip)
+    skills = crud.skill.get_multi(db, skip=skip, active_only=active_only)
     if not skills:
         raise HTTPException(
             status_code=404,

--- a/backend/app/crud/base.py
+++ b/backend/app/crud/base.py
@@ -29,6 +29,14 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     def get_multi(
         self, db: Session, *, skip: int = 0, limit: int = 100, active_only: bool = False
     ) -> List[ModelType]:
+        if active_only:
+            return (
+                db.query(self.model)
+                .filter(self.model.is_active == active_only)
+                .offset(skip)
+                .limit(limit)
+                .all()
+            )
         return db.query(self.model).offset(skip).limit(limit).all()
 
     def create(self, db: Session, *, obj_in: CreateSchemaType) -> ModelType:

--- a/backend/app/tests/api/api_v1/test_skill.py
+++ b/backend/app/tests/api/api_v1/test_skill.py
@@ -9,7 +9,6 @@ def test_get_all_skills_non_existent(client: TestClient, db: Session) -> None:
     response = client.get(
         f"{settings.API_V1_STR}/skill/all",
     )
-    print(response.json())
     assert response.status_code == 404
     content = response.json()
     assert content["detail"] == "Skills not found"
@@ -55,6 +54,26 @@ def test_get_all_skills(client: TestClient, db: Session) -> None:
             is_course_in_response = True
             break
     assert is_course_in_response
+
+
+def test_get_all_skills_active_only(client: TestClient, db: Session) -> None:
+    skill = create_random_skill(db, is_active=False)
+    response = client.get(
+        f"{settings.API_V1_STR}/skill/all?active_only=true",
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert len(content) == 2
+
+    course_not_in_response = True
+    for obj in content:
+        if obj["skill_id"] == skill.skill_id:
+            assert obj["skill_name"] == skill.skill_name
+            assert obj["skill_desc"] == skill.skill_desc
+            assert obj["is_active"] == skill.is_active
+            course_not_in_response = False
+            break
+    assert course_not_in_response
 
 
 def test_create_skill_no_desc(client: TestClient, db: Session) -> None:

--- a/backend/app/tests/utils/skill.py
+++ b/backend/app/tests/utils/skill.py
@@ -2,18 +2,17 @@ from sqlalchemy.orm import Session
 
 from app import crud, models
 from app.schemas.skill import SkillCreate
-from app.tests.utils.utils import random_boolean, random_lower_string, random_numbers
+from app.tests.utils.utils import random_lower_string, random_numbers
 
 SKILL_ID_LENGTH = 5
 SKILL_NAME_LENGTH = 50
 SKILL_DESC_LENGTH = 255
 
 
-def create_random_skill(db: Session) -> models.Skill:
+def create_random_skill(db: Session, is_active: bool = True) -> models.Skill:
     skill_id = random_numbers(SKILL_ID_LENGTH)
     skill_name = random_lower_string(SKILL_NAME_LENGTH)
     skill_desc = random_lower_string(SKILL_DESC_LENGTH)
-    is_active = random_boolean()
 
     skill_in = SkillCreate(
         skill_id=skill_id,


### PR DESCRIPTION
# Description
<!-- Please add link to Jira Ticket here -->
Fixes [Jira ticket #G7T5-100](https://is212g7t5.atlassian.net/browse/G7T5-100)
<!-- Add Screenshots if there are changes or additions in frontend components -->

- Updates the base crud model `get_multi` to have an optional query param of `active_only`
- Adds optional query param of `active_only` to `/skill/all` endpoint to retrieve only active skills if query param is `true`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

- [x] G7T5-1-23

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
