### PR TITLE
Add netlify url to list of accepted origins

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
         "http://localhost:3000",
         "http://localhost:8080",
         "http://localhost:8081",
+        "https://spm-g7t5.netlify.app",
     ]
 
     @validator("BACKEND_CORS_ORIGINS", pre=True)


### PR DESCRIPTION
# Description
<!-- Please add link to Jira Ticket here -->

Currently, the netlify environment cannot make requests to the production backend, which seems to be blocked by CORS errors. Adding in the netlify url should allow it to be an accepted origin.

<!-- Add Screenshots if there are changes or additions in frontend components -->
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

- NA

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
