### PR TITLE
[G7T5-116] Allow job PUT to accept own job name

### DIFF
--- a/backend/app/api/api_v1/endpoints/job.py
+++ b/backend/app/api/api_v1/endpoints/job.py
@@ -114,11 +114,13 @@ def update_job_by_id(
             status_code=404,
             detail="Job not found",
         )
-    if job_in.job_name and crud.job.get_by_job_name(db, job_name=job_in.job_name):
-        raise HTTPException(
-            status_code=409,
-            detail="job_name already exists",
-        )
+    if job_in.job_name:
+        existing_job = crud.job.get_by_job_name(db, job_name=job_in.job_name)
+        if existing_job and existing_job != job:
+            raise HTTPException(
+                status_code=409,
+                detail="job_name already exists",
+            )
     return crud.job.update(db, db_obj=job, obj_in=job_in)
 
 

--- a/backend/app/api/api_v1/endpoints/skill.py
+++ b/backend/app/api/api_v1/endpoints/skill.py
@@ -1,9 +1,9 @@
-from typing import Any, List
 import json
+from typing import Any, List
 
 from fastapi import APIRouter, Body, Depends, HTTPException
-from sqlalchemy.orm import Session
 from sqlalchemy import text
+from sqlalchemy.orm import Session
 
 from app import crud, schemas
 from app.api import deps

--- a/backend/app/tests/api/api_v1/test_job.py
+++ b/backend/app/tests/api/api_v1/test_job.py
@@ -375,6 +375,21 @@ def test_update_job_duplicate_job_name(client: TestClient, db: Session) -> None:
     assert content["detail"] == "job_name already exists"
 
 
+def test_update_job_own_job_name(client: TestClient, db: Session) -> None:
+    job = create_random_job(db)
+    data = {"job_name": job.job_name}
+    response = client.put(
+        f"{settings.API_V1_STR}/job/{job.job_id}",
+        json=data,
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["job_id"] == job.job_id
+    assert content["job_desc"] == job.job_desc
+    assert content["is_active"] == job.is_active
+    assert content["job_name"] == data["job_name"] == job.job_name
+
+
 def test_update_job_white_space_job_name(client: TestClient, db: Session) -> None:
     job = create_random_job(db)
     job_name = random_lower_string(50)


### PR DESCRIPTION
# Description
<!-- Please add link to Jira Ticket here -->
Fixes [Jira ticket #G7T5-116](https://is212g7t5.atlassian.net/browse/G7T5-116)

Currently, the `PUT /job/{job_id}` endpoint will return a `409` response if it is attempted to update a job with its own job name. The existing logic suggests that as long as the job name exists in the database, a `409` is returned.

However, this is poor design of idempotence on PUT endpoints. Instead, if the job being updated is updating its fields with its own existing values, this should not result in any error. Instead, it should be a `200` success response, except that there is no net change in data.

This fix checks if the job with the existing name is itself, and if so, avoid returning a `409`.

<!-- Add Screenshots if there are changes or additions in frontend components -->
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

- [x] G7T5-2-5
- [x] G7T5-2-6

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
