### PR TITLE
[G7T5-125] Add is_active query param for /job/skills

### DIFF
--- a/backend/app/api/api_v1/endpoints/job.py
+++ b/backend/app/api/api_v1/endpoints/job.py
@@ -30,6 +30,7 @@ def get_all_job(
 @router.get("/skills")
 def get_all_jobs_and_all_skills(
     db: Session = Depends(deps.get_db),
+    active_only: bool = False,
 ) -> Any:
     """
     Get all jobs and all their skills.
@@ -47,8 +48,10 @@ def get_all_jobs_and_all_skills(
         s.Is_Active as is_skill_active
     FROM job as j
     LEFT JOIN job_skill ON j.job_ID = job_skill.job_ID
-    LEFT JOIN skill as s ON job_skill.Skill_ID = s.Skill_ID;
-    """
+    LEFT JOIN skill as s ON job_skill.Skill_ID = s.Skill_ID{};
+    """.format(
+            " WHERE j.is_active = 1" if active_only else ""
+        )
     )
     db_cursor_obj = db.execute(sql_query)
     if not db_cursor_obj:

--- a/backend/app/crud/crud_job.py
+++ b/backend/app/crud/crud_job.py
@@ -18,6 +18,7 @@ class CRUDJob(CRUDBase[Job, JobCreate, JobUpdate]):
         db_obj = Job(
             job_name=obj_in.job_name,
             job_desc=obj_in.job_desc,
+            is_active=obj_in.is_active,
         )
         db.add(db_obj)
         db.commit()

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -26,7 +26,7 @@ class JobBase(BaseModel):
 
 # Properties to receive via API on creation
 class JobCreate(JobBase):
-    pass
+    is_active: Optional[bool] = True
 
 
 # Properties to receive via API on update

--- a/backend/app/tests/utils/job.py
+++ b/backend/app/tests/utils/job.py
@@ -8,8 +8,8 @@ JOB_NAME_LENGTH = 50
 JOB_DESC_LENGTH = 255
 
 
-def create_random_job(db: Session) -> models.Job:
+def create_random_job(db: Session, is_active: bool = True) -> models.Job:
     job_name = random_lower_string(JOB_NAME_LENGTH)
     job_desc = random_lower_string(JOB_DESC_LENGTH)
-    job_in = JobCreate(job_name=job_name, job_desc=job_desc)
+    job_in = JobCreate(job_name=job_name, job_desc=job_desc, is_active=is_active)
     return crud.job.create(db=db, obj_in=job_in)

--- a/backend/app/tests/utils/job_skill.py
+++ b/backend/app/tests/utils/job_skill.py
@@ -6,8 +6,11 @@ from app.tests.utils.job import create_random_job
 from app.tests.utils.skill import create_random_skill
 
 
-def create_random_job_skill(db: Session) -> models.Job_Skill:
-    job = create_random_job(db)
+def create_random_job_skill(
+    db: Session,
+    job: models.Job = None,
+) -> models.Job_Skill:
+    job = job or create_random_job(db)
     skill = create_random_skill(db)
 
     job_skill_in = JobSkillCreate(job_id=job.job_id, skill_id=skill.skill_id)


### PR DESCRIPTION
# Description
<!-- Please add link to Jira Ticket here -->
Fixes [Jira ticket #G7T5-125](https://is212g7t5.atlassian.net/browse/G7T5-125)
<!-- Add Screenshots if there are changes or additions in frontend components -->

Adds an optional `active_only` query param to the `/job/skills` endpoint to only return active jobs if the query param is set to `true`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor

# How Has This Been Tested?
- [ ] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

None currently, will add in the subsequent frontend change

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
