### PR TITLE
[G7T5-126] Display only active jobs for Staff

### DIFF
--- a/app/src/api/jobs.js
+++ b/app/src/api/jobs.js
@@ -19,7 +19,19 @@ export const getAllJobsAndSkills = async () => {
   try {
     const res = await axios.get(`${JOB_ENDPOINT}/skills`);
     if (res) {
-      console.log(combineSkillsToJobs(res.data))
+      return combineSkillsToJobs(res.data);
+    }
+    throw new Error("No data returned from backend");
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+};
+
+export const getAllActiveJobsAndSkills = async () => {
+  try {
+    const res = await axios.get(`${JOB_ENDPOINT}/skills?active_only=true`);
+    if (res) {
       return combineSkillsToJobs(res.data);
     }
     throw new Error("No data returned from backend");

--- a/app/src/api/jobs.js
+++ b/app/src/api/jobs.js
@@ -15,22 +15,9 @@ export const getJobs = async () => {
   }
 };
 
-export const getAllJobsAndSkills = async () => {
+export const getAllJobsAndSkills = async (activeOnly=false) => {
   try {
-    const res = await axios.get(`${JOB_ENDPOINT}/skills`);
-    if (res) {
-      return combineSkillsToJobs(res.data);
-    }
-    throw new Error("No data returned from backend");
-  } catch (error) {
-    console.log(error);
-    return [];
-  }
-};
-
-export const getAllActiveJobsAndSkills = async () => {
-  try {
-    const res = await axios.get(`${JOB_ENDPOINT}/skills?active_only=true`);
+    const res = await axios.get(`${JOB_ENDPOINT}/skills?active_only=${activeOnly}`);
     if (res) {
       return combineSkillsToJobs(res.data);
     }

--- a/app/src/components/job/staff/StaffJob.jsx
+++ b/app/src/components/job/staff/StaffJob.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { getAllActiveJobsAndSkills } from "src/api/jobs";
+import { getAllJobsAndSkills } from "src/api/jobs";
 import { toast } from "react-toastify";
 import JobTile from "../JobTile";
 
@@ -24,7 +24,7 @@ function StaffJob() {
     getAllJobs();
 
     async function getAllJobs() {
-      const jobsReturnedFromBackend = await getAllActiveJobsAndSkills();
+      const jobsReturnedFromBackend = await getAllJobsAndSkills(true);
       // const jobsReturnedFromBackend = [];
       if (jobsReturnedFromBackend.length === 0) {
         toast.warning("There are no jobs to display");

--- a/app/src/components/job/staff/StaffJob.jsx
+++ b/app/src/components/job/staff/StaffJob.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { getAllJobsAndSkills } from "src/api/jobs";
+import { getAllActiveJobsAndSkills } from "src/api/jobs";
 import { toast } from "react-toastify";
 import JobTile from "../JobTile";
 
@@ -18,10 +18,10 @@ function StaffJob() {
   ));
 
   useEffect(() => {
-    getAllJobs(); // TODO: Change to getAllActiveJobs, Staff should not retrieve active jobs
+    getAllJobs();
 
     async function getAllJobs() {
-      const jobsReturnedFromBackend = await getAllJobsAndSkills();
+      const jobsReturnedFromBackend = await getAllActiveJobsAndSkills();
       // const jobsReturnedFromBackend = [];
       if (jobsReturnedFromBackend.length === 0) {
         toast.warning("There are no jobs to display");

--- a/app/src/components/job/staff/StaffJob.jsx
+++ b/app/src/components/job/staff/StaffJob.jsx
@@ -6,16 +6,19 @@ import JobTile from "../JobTile";
 function StaffJob() {
   const [jobs, setJobs] = useState([]);
 
-  const renderJobs = jobs.map(({ jobId, jobName, jobDesc, skills, isActive }, index) => (
-    <JobTile
+  const renderJobs = jobs.map(({ jobId, jobName, jobDesc, skills, isActive }, index) => {
+    if (isActive === 1) {
+      return <JobTile
       key={index}
       jobId={jobId}
       jobName={jobName}
       jobDesc={jobDesc}
       skills={skills}
       isActive={isActive}
-    />
-  ));
+      /> ;
+    }
+    return null;
+  });
 
   useEffect(() => {
     getAllJobs();


### PR DESCRIPTION
# Description
<!-- Please add link to Jira Ticket here -->
Fixes [Jira ticket #G7T5-126](https://is212g7t5.atlassian.net/browse/G7T5-126)

Currently, Staff's `/jobs` page displays all jobs, regardless of whether it is active or inactive. This should not be the case as Staff are only able to view active jobs. This fix switches the API reference to populate the Staff's `/jobs` page using the `active_only` filter so as to only retrieve and display active jobs.

<!-- Add Screenshots if there are changes or additions in frontend components -->
### HR view - able to see inactive jobs
<img width="1297" alt="Screen Shot 2022-10-13 at 8 03 36 AM" src="https://user-images.githubusercontent.com/84013254/195470228-b19f6948-3b47-4204-a6c9-874be7c7ab47.png">

### Staff view - unable to see inactive jobs
<img width="1271" alt="Screen Shot 2022-10-13 at 8 03 46 AM" src="https://user-images.githubusercontent.com/84013254/195470214-e19a36ca-18a9-40d2-b7ce-65f6f7c0e2aa.png">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

- [x] G7T5-115-1
- [x] G7T5-115-2
- [x] G7T5-115-3

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
