### PR TITLE
[G7T5-131] Add backend validation for skill fields

### DIFF
--- a/backend/alembic/versions/0009_alter_skill_table.py
+++ b/backend/alembic/versions/0009_alter_skill_table.py
@@ -1,0 +1,35 @@
+"""Alter skill Table
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2022-10-17 00:00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+UPGRADE_SQL = """
+ALTER TABLE skill
+ADD INDEX `index_skill_name` (skill_name),
+MODIFY skill_desc varchar(255) NOT NULL;
+"""
+
+DOWNGRADE_SQL = """
+ALTER TABLE skill
+MODIFY skill_desc varchar(255) DEFAULT NULL,
+DROP INDEX `index_skill_name`;
+"""
+
+
+def upgrade():
+    op.execute(UPGRADE_SQL)
+
+
+def downgrade():
+    op.execute(DOWNGRADE_SQL)

--- a/backend/app/crud/crud_skill.py
+++ b/backend/app/crud/crud_skill.py
@@ -11,9 +11,11 @@ class CRUDSkill(CRUDBase[Skill, SkillCreate, SkillUpdate]):
     def get(self, db: Session, skill_id: Any) -> Skill:
         return db.query(self.model).filter(self.model.skill_id == skill_id).first()
 
+    def get_by_skill_name(self, db: Session, skill_name: Any) -> Skill:
+        return db.query(self.model).filter(self.model.skill_name == skill_name).first()
+
     def create(self, db: Session, *, obj_in: SkillCreate) -> Skill:
         db_obj = Skill(
-            skill_id=obj_in.skill_id,
             skill_name=obj_in.skill_name,
             skill_desc=obj_in.skill_desc,
             is_active=obj_in.is_active,

--- a/backend/app/schemas/skill.py
+++ b/backend/app/schemas/skill.py
@@ -1,28 +1,46 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 
 # Shared properties
 class SkillBase(BaseModel):
-    skill_id: Optional[int]
     skill_name: str
-    skill_desc: Optional[str]
-    is_active: bool
+    skill_desc: str
+
+    @validator("skill_name")
+    @classmethod
+    def validate_skill_name(cls, skill_name):
+        skill_name = skill_name.strip()
+        assert len(skill_name) >= 1, "Skill name must minimally be 1 character long"
+        assert len(skill_name) <= 50, "Skill name cannot exceed 50 characters"
+        return skill_name
+
+    @validator("skill_desc")
+    @classmethod
+    def validate_job_desc(cls, skill_desc):
+        assert (
+            len(skill_desc) >= 1
+        ), "Skill description must minimally be 1 character long"
+        assert len(skill_desc) <= 255, "Skill description cannot exceed 255 characters"
+        return skill_desc
 
 
 # Properties to receive via API on creation
 class SkillCreate(SkillBase):
-    pass
+    is_active: Optional[bool] = True
 
 
 # Properties to receive via API on update
 class SkillUpdate(SkillBase):
-    pass
+    skill_name: Optional[str] = None
+    skill_desc: Optional[str] = None
+    is_active: Optional[bool] = None
 
 
 class SkillInDBBase(SkillBase):
-    skill_id: int
+    skill_id: Optional[int] = None
+    is_active: bool = True
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
# Description
<!-- Please add link to Jira Ticket here -->
Fixes [Jira ticket #G7T5-131](https://is212g7t5.atlassian.net/browse/G7T5-131)

<!-- Add Screenshots if there are changes or additions in frontend components -->

The Skills schema in the backend currently does not align with the data field requirements in the acceptance criteria, and neither are field validation conducted. This PR aims to resolve these issues.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

**Test cases added, but will only be tested in [frontend PR](https://github.com/is212g7t5/spm/pull/74)**

- [x] G7T5-14-1
- [x] G7T5-14-2
- [x] G7T5-14-3
- [x] G7T5-14-4
- [x] G7T5-14-5
- [x] G7T5-14-6
- [x] G7T5-14-7
- [x] G7T5-14-8
- [x] G7T5-14-9
- [x] G7T5-14-10
- [x] G7T5-14-11


# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
