### PR TITLE
[G7T5-145] Display LJs for inactive job roles, disable editing of LJ

### DIFF
--- a/app/src/components/learningJourney/DropdownButton.jsx
+++ b/app/src/components/learningJourney/DropdownButton.jsx
@@ -17,7 +17,7 @@ function DropdownButton({ onDeletionModalClick, navigateToLJDetails }) {
               className='block w-100 py-2 px-4 text-sm text-black hover:bg-gray-100'
               onClick={handleButtonClick}
             >
-              Edit
+              View
             </button>
           </li>
           <li>

--- a/app/src/components/learningJourney/LearningJourneyTile.jsx
+++ b/app/src/components/learningJourney/LearningJourneyTile.jsx
@@ -10,10 +10,6 @@ function LearningJourneyTile({
   onDeletionModalClick,
   setSelectedLJ,
 }) {
-  if (!isJobActive) {
-    return null;
-  }
-
   const [isDropdownButtonClicked, setIsDropdownButtonClicked] = useState(false);
 
   const history = useHistory();
@@ -63,10 +59,21 @@ function LearningJourneyTile({
           alt='Person'
         />
         <h5 className='mb-1 text-xl font-medium text-black'>Learning Journey {LJId}</h5>
-        <span className='text-md text-black italic'>{jobName}</span>
+        <span className={"text-md italic " + (isJobActive ? "text-black" : "text-gray-500")}>
+          {jobName}
+          {isJobActive ? "" : <CreateInactiveBadge />}
+        </span>
         <span className='text-sm p-5 text-center'>{jobDesc}</span>
       </div>
     </div>
+  );
+}
+
+function CreateInactiveBadge() {
+  return (
+    <span className='ml-1 bg-gray-100 text-gray-500 mr-2 px-2.5 py-0.5 rounded'>
+      Inactive
+    </span>
   );
 }
 

--- a/app/src/components/learningJourney/details/AddCourseButton.jsx
+++ b/app/src/components/learningJourney/details/AddCourseButton.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { PencilIcon } from "@heroicons/react/20/solid";
 
-export default function AddCourseButton({ startLJEditProcess }) {
+export default function AddCourseButton({ startLJEditProcess, isJobActive }) {
 
   return (
     <button
       type='button'
-      className='inline-flex items-center place-content-center bg-secondary text-white outline-gray-400 w-48 h-12 rounded-lg shadow-md hover:underline underline-offset-2'
-      onClick={startLJEditProcess}
+      className={(isJobActive ? "bg-secondary hover:underline underline-offset-2" : "bg-gray-400 cursor-not-allowed") + " inline-flex items-center place-content-center w-48 h-12 text-white rounded-lg shadow-md"}
+      onClick={(isJobActive ? startLJEditProcess : "")}
     >
       <PencilIcon className='h-4 w-6' />
       <span>Edit Learning Journey</span>

--- a/app/src/components/learningJourney/details/JobBadge.jsx
+++ b/app/src/components/learningJourney/details/JobBadge.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function JobBadge({ jobName, isActive }) {
     return (
-        <div className={`py-2 max-h-44 ${isActive ? "bg-primary" : "bg-gray-100"} text-white rounded-lg shadow-md text-base text-center overflow-hidden text-ellipsis font-semibold`}>
+        <div className={`py-2 max-h-44 ${isActive ? "bg-primary text-white" : "bg-gray-100 text-gray-500"} rounded-lg shadow-md text-base text-center overflow-hidden text-ellipsis font-semibold`}>
             {jobName}
         </div>
     )

--- a/app/src/components/learningJourney/details/index.jsx
+++ b/app/src/components/learningJourney/details/index.jsx
@@ -101,7 +101,7 @@ function LearningJourneyDetails() {
           isJobActive={isJobActive}
         />
       </div>
-      <AddCourseButton startLJEditProcess={startLJEditProcess} />
+      <AddCourseButton startLJEditProcess={startLJEditProcess} isJobActive={isJobActive} />
     </div>
   );
 }

--- a/app/src/components/learningJourney/staff/StaffLearningJourney.jsx
+++ b/app/src/components/learningJourney/staff/StaffLearningJourney.jsx
@@ -17,7 +17,7 @@ function StaffLearningJourney({ staffId }) {
   useEffect(() => {
     let result;
     const jobsPromise = [];
-    getAllLearningJourneysAndDetails(); // TODO: Change to getAllActiveJobs, Staff should not retrieve active jobs
+    getAllLearningJourneysAndDetails();
 
     async function getAllLearningJourneysAndDetails() {
       if (!staffId) {


### PR DESCRIPTION
# Description
Fixes https://is212g7t5.atlassian.net/browse/G7T5-145

- Display LJs whose job roles are inactive
- Indicate inactive status of job roles for these LJs
- Disable edit LJ button for those with inactive job roles

https://user-images.githubusercontent.com/71003267/197244763-122772df-e248-484d-93e6-36f165180a7e.mp4

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
