### PR TITLE
[G7T5-161, G7T5-162] Staff view only own Learning Journey

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -4,6 +4,8 @@ import { UserProvider } from "src/contexts/UserContext";
 import { LJContextProvider } from "src/contexts/LJContext";
 import { UpdateJobContextProvider } from "src/contexts/UpdateJobContext";
 import { UpdateSkillContextProvider } from "src/contexts/UpdateSkillContext";
+import { StaffContextProvider } from "src/contexts/StaffContext";
+
 import {
   Courses,
   Jobs,
@@ -13,7 +15,7 @@ import {
   CreateLearningJourneyPage,
   Skills,
   CreateSkill,
-  UpdateSkill
+  UpdateSkill,
 } from "src/routes";
 
 import Layout from "./layout";
@@ -23,40 +25,46 @@ import "react-toastify/dist/ReactToastify.css";
 function App() {
   return (
     <Router>
-      <LJContextProvider>
-        <UpdateJobContextProvider>
-          <UpdateSkillContextProvider>
-            <UserProvider>
-              <Layout>
-                <Switch>
-                  <Route exact path='/' component={LearningJourneys} />
-                  <Route path='/learning-journeys' component={LearningJourneys} />
-                  <Route exact path='/create-learning-journey' component={CreateLearningJourneyPage} />
-                  <Route exact path='/courses' component={Courses} />
-                  <Route exact path='/skills' component={Skills} />
-                  <Route exact path='/create-skill' component={CreateSkill} />
-                  <Route exact path='/jobs' component={Jobs} />
-                  <Route exact path='/create-job' component={CreateJob} />
-                  <Route exact path='/update-job' component={UpdateJob} />
-                  <Route exact path='/update-skill' component={UpdateSkill} />
-                </Switch>
-              </Layout>
-              <ToastContainer
-                position='bottom-right'
-                autoClose={3000}
-                hideProgressBar={false}
-                newestOnTop
-                closeOnClick
-                rtl={false}
-                pauseOnFocusLoss={false}
-                draggable
-                pauseOnHover={false}
-                theme='colored'
-              />
-            </UserProvider>
-          </UpdateSkillContextProvider>
-        </UpdateJobContextProvider>
-      </LJContextProvider>
+      <StaffContextProvider>
+        <LJContextProvider>
+          <UpdateJobContextProvider>
+            <UpdateSkillContextProvider>
+              <UserProvider>
+                <Layout>
+                  <Switch>
+                    <Route exact path='/' component={LearningJourneys} />
+                    <Route path='/learning-journeys' component={LearningJourneys} />
+                    <Route
+                      exact
+                      path='/create-learning-journey'
+                      component={CreateLearningJourneyPage}
+                    />
+                    <Route exact path='/courses' component={Courses} />
+                    <Route exact path='/skills' component={Skills} />
+                    <Route exact path='/create-skill' component={CreateSkill} />
+                    <Route exact path='/jobs' component={Jobs} />
+                    <Route exact path='/create-job' component={CreateJob} />
+                    <Route exact path='/update-job' component={UpdateJob} />
+                    <Route exact path='/update-skill' component={UpdateSkill} />
+                  </Switch>
+                </Layout>
+                <ToastContainer
+                  position='bottom-right'
+                  autoClose={3000}
+                  hideProgressBar={false}
+                  newestOnTop
+                  closeOnClick
+                  rtl={false}
+                  pauseOnFocusLoss={false}
+                  draggable
+                  pauseOnHover={false}
+                  theme='colored'
+                />
+              </UserProvider>
+            </UpdateSkillContextProvider>
+          </UpdateJobContextProvider>
+        </LJContextProvider>
+      </StaffContextProvider>
     </Router>
   );
 }

--- a/app/src/components/learningJourney/details/AddCourseButton.jsx
+++ b/app/src/components/learningJourney/details/AddCourseButton.jsx
@@ -7,7 +7,7 @@ export default function AddCourseButton({ startLJEditProcess, isJobActive }) {
     <button
       type='button'
       className={(isJobActive ? "bg-secondary hover:underline underline-offset-2" : "bg-gray-400 cursor-not-allowed") + " inline-flex items-center place-content-center w-48 h-12 text-white rounded-lg shadow-md"}
-      onClick={(isJobActive ? startLJEditProcess : "")}
+      onClick={(isJobActive ? startLJEditProcess : () => {})}
     >
       <PencilIcon className='h-4 w-6' />
       <span>Edit Learning Journey</span>

--- a/app/src/components/learningJourney/details/index.jsx
+++ b/app/src/components/learningJourney/details/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useUserContext } from "src/contexts/UserContext";
 import { useLJContext } from "src/contexts/LJContext";
+import { useStaffContext } from "src/contexts/StaffContext";
 import { useHistory, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 
@@ -17,6 +18,7 @@ import AddCourseButton from "./AddCourseButton";
 
 function LearningJourneyDetails() {
   const { currentUserId } = useUserContext();
+  const { learningJourneys } = useStaffContext();
   const { setSelectedLJId, setSelectedJobRole, setSelectedCourseDetails } = useLJContext();
 
   const { LJId } = useParams();
@@ -29,6 +31,23 @@ function LearningJourneyDetails() {
 
   const [LJCourseIds, setLJCourseIds] = useState([]);
   const [LJCourseDetails, setLJCourseDetails] = useState({});
+
+  useEffect(() => {
+    if (!currentUserId) {
+      history.push("/login");
+    }
+
+    if (!LJId) {
+      toast.error("No Learning Journey ID provided");
+      history.push("/learning-journeys");
+    }
+
+    const isLJBelongToStaff = learningJourneys.find((LJObject) => LJObject.LJId === Number(LJId));
+    if (!isLJBelongToStaff) {
+      toast.error("Invalid Access");
+      history.push("/learning-journeys");
+    }
+  }, [currentUserId, LJId]);
 
   useEffect(() => {
     getAllCoursesForLJ(LJId);
@@ -81,12 +100,6 @@ function LearningJourneyDetails() {
     setSelectedCourseDetails(LJCourseDetails);
     history.push("/create-learning-journey?isEdit=true", { isEditing: true });
   };
-
-  // Validation for LJ ID here if needed in future
-  if (!LJId) {
-    toast.error("No Learning Journey ID provided");
-    history.push("/learning-journeys");
-  }
 
   return (
     <div className='flex flex-col container w-11/12 max-w-7xl p-5 mx-auto w-full justify-around'>

--- a/app/src/components/learningJourney/staff/StaffLearningJourney.jsx
+++ b/app/src/components/learningJourney/staff/StaffLearningJourney.jsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { toast } from "react-toastify";
+import { useStaffContext } from "src/contexts/StaffContext";
 import { getJobById } from "src/api/jobs";
 import { getLearningJourneysByStaffId } from "src/api/learningJourney";
 import LearningJourneyTile from "../LearningJourneyTile";
 import LJDeletionPopUp from "../details/LJDeletionPopUp";
 
 function StaffLearningJourney({ staffId }) {
-  const [learningJourneys, setLearningJourneys] = useState([]);
+  const { learningJourneys, setLearningJourneys } = useStaffContext();
+  
   const [selectedLJ, setSelectedLJ] = useState(null);
   const [isDeletionModalOpen, setIsDeletionModalOpen] = useState(false);
   const [isDeletionButtonClicked, setIsDeletionButtonClicked] = useState(false);
@@ -41,9 +43,10 @@ function StaffLearningJourney({ staffId }) {
         learningJourneysReturnedFromBackend[i].jobDesc = result[i].jobDesc;
         learningJourneysReturnedFromBackend[i].isJobActive = result[i].isActive;
       }
+
       setLearningJourneys(learningJourneysReturnedFromBackend);
     }
-  }, [isDeletionButtonClicked]);
+  }, [staffId]);
 
   const renderLearningJourneys = learningJourneys.map(
     ({ LJId, jobName, jobDesc, isJobActive }, index) => (

--- a/app/src/contexts/StaffContext.jsx
+++ b/app/src/contexts/StaffContext.jsx
@@ -1,0 +1,27 @@
+import React, { useState, createContext, useContext, useMemo } from "react";
+
+// Do not remove default unused vars as typescript uses this for type hinting
+const defaultStaffContextState = {
+  learningJourneys: [],
+  setLearningJourneys: (learningJourneys) => {},
+};
+const StaffContext = createContext(defaultStaffContextState);
+
+export function StaffContextProvider({ children }) {
+  const [learningJourneys, setLearningJourneys] = useState([]);
+
+  const StaffContextState = useMemo(
+    () => ({
+      learningJourneys,
+      setLearningJourneys,
+    }),
+    [learningJourneys, setLearningJourneys],
+  );
+
+  return <StaffContext.Provider value={StaffContextState}>{children}</StaffContext.Provider>;
+}
+
+// Helper functions
+export function useStaffContext() {
+  return useContext(StaffContext);
+}


### PR DESCRIPTION
# Description
https://is212g7t5.atlassian.net/browse/G7T5-161

Staff will now no longer be able to access LJs from the URL.

When you try to access LJs from the URL, you will be re-directed to main LJ page.
<img width="522" alt="image" src="https://user-images.githubusercontent.com/58715320/198937386-e73fa5cf-aabd-4901-af14-ddc6e3133d75.png">

Note: This fix will also 'disable' the feature that Staff can now access their OWN LJ from the URL. However I feel this is an alright fix because handling that case will result in added complexity. We can add this into the backlog to implement this feature in the future because it is currently not needed.

Commits
[Fix onclick semantics to make sure its a fn call]
[Add Staff Context]
[Allow only LJ details access only from LJ page]

**Acceptance Criterias**
- [x] Staff can only view LJs belonging to them
- [x] Staff can only view 1 LJ’s details at once
- [x] Learning Journey should show all relevant details:
CourseID, Course Name, and status of the courses added into LJ
Skills of each course added into LJ
Name of Job Role for the LJ
Active status of Job Role for the LJ
Skills required for Job Role of LJ
- [x] LJ can be viewed on both mobile and desktop devices
- [x] Time taken to load LJ details should not be more than 5 seconds

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

- [x] G7T5-161-1
- [x] G7T5-161-2
- [x] G7T5-161-3
- [x] G7T5-161-4

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
