### PR TITLE
[G7T5-151] Display only active courses when selecting a Skill in LJ

### DIFF
--- a/app/src/components/createLearningJourney/CourseModal.jsx
+++ b/app/src/components/createLearningJourney/CourseModal.jsx
@@ -79,14 +79,19 @@ function CloseModalButton({ closeModal }) {
 function ModalBody({ skillId, coursesAndSkillsMapping, selectedCourses, setSelectedCourses }) {
   const targetSkillWithCourses = coursesAndSkillsMapping.find((item) => item.skillId === skillId);
 
-  const renderCourses = targetSkillWithCourses.courses.map((course, index) => (
-    <CourseRow
-      selectedCourses={selectedCourses}
-      setSelectedCourses={setSelectedCourses}
-      course={course}
-      key={index}
-    />
-  ));
+  const renderCourses = targetSkillWithCourses.courses.map((course, index) => {
+    if (course.courseStatus === "Active") {
+      return (
+        <CourseRow
+          selectedCourses={selectedCourses}
+          setSelectedCourses={setSelectedCourses}
+          course={course}
+          key={index}
+        />
+      )
+    }
+    return null;
+  });
 
   return (
     <div


### PR DESCRIPTION
# Description
<!-- Please add link to Jira Ticket here -->
Fixes [Jira ticket #G7T5-187](https://is212g7t5.atlassian.net/browse/G7T5-187)
<!-- Add Screenshots if there are changes or additions in frontend components -->

**Before**

![Screen Shot 2022-11-01 at 5 40 40 PM](https://user-images.githubusercontent.com/84013254/199205995-3f94a940-80cc-4d79-bbd0-d2e82c77210b.png)

**After**

![Screen Shot 2022-11-01 at 5 40 59 PM](https://user-images.githubusercontent.com/84013254/199206021-47dc18c5-95b2-41c5-9042-d4c4e89d2fd7.png)

List all acceptance criterias of user story and indicate which has been solved previously and which is solved currently
- [x] Staff should only be able to view active courses, and unable to view pending or retired courses (solving)
- [x] Staff able to view a list of courses corresponding to the selected skill (solved)
- [x] Staff should not be able to see any courses if no skill is selected (solved)
- [x] Course Name, Course Category to be shown. (solved)
- [x] Staff should be able to courses on both mobile and desktop devices (solved)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using

- [x] G7T5-151-2

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
