### PR TITLE
[G7T5-146] Only display active skills for all cases for Staff

### DIFF
--- a/app/src/api/course.js
+++ b/app/src/api/course.js
@@ -33,9 +33,23 @@ export const getCourseById = async (courseId) => {
   }
 }
 
+export const getAllCoursesAndActiveSkills = async () => {
+  try {
+    const res = await axiosCourseInstance.get("/skills/active");
+    if (res) {
+      return transformCoursesWithSkills(res.data);
+    }
+    throw new Error("No data returned from backend");
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+}
+
 function transformSnakeCourses(snakeCourses) {
   return snakeCourses.map((course) => courseSnakeToCamel(course));
 }
+
 function courseSnakeToCamel(snakeCaseCourse) {
   return {
     courseId: snakeCaseCourse.course_id,
@@ -45,5 +59,35 @@ function courseSnakeToCamel(snakeCaseCourse) {
     courseType: snakeCaseCourse.course_type,
     courseCategory: snakeCaseCourse.course_category,
     isActive: snakeCaseCourse.is_active,
+  };
+}
+
+function transformCoursesWithSkills(snakeCaseCourses) {
+  return snakeCaseCourses.map((course) => transformCourseWithSkills(course));
+}
+
+function transformCourseWithSkills(snakeCaseCourse) {
+  const transformedSkills = transformSkills(snakeCaseCourse.skills);
+  return {
+    courseId: snakeCaseCourse.course_id,
+    courseName: snakeCaseCourse.course_name,
+    courseDesc: snakeCaseCourse.course_desc,
+    courseStatus: snakeCaseCourse.course_status,
+    courseType: snakeCaseCourse.course_type,
+    courseCategory: snakeCaseCourse.course_category,
+    skills: transformedSkills
+  };
+}
+
+function transformSkills(snakeCaseSkills) {
+  return snakeCaseSkills.map((skill) => transformSkill(skill));
+}
+
+function transformSkill(snakeCaseSkill) {
+  return {
+    skillId: snakeCaseSkill.skill_id,
+    skillName: snakeCaseSkill.skill_name,
+    skillDesc: snakeCaseSkill.skill_desc,
+    isActive: snakeCaseSkill.is_active,
   };
 }

--- a/app/src/api/jobs.js
+++ b/app/src/api/jobs.js
@@ -15,9 +15,9 @@ export const getJobs = async () => {
   }
 };
 
-export const getAllJobsAndSkills = async (activeOnly=false) => {
+export const getAllJobsAndSkills = async (activeJobAndSkillsOnly=false) => {
   try {
-    const res = await axios.get(`${JOB_ENDPOINT}/skills?active_only=${activeOnly}`);
+    const res = await axios.get(`${JOB_ENDPOINT}/skills?active_only=${activeJobAndSkillsOnly}`);
     if (res) {
       return combineSkillsToJobs(res.data);
     }

--- a/app/src/components/course/CourseDescription.jsx
+++ b/app/src/components/course/CourseDescription.jsx
@@ -1,9 +1,9 @@
 import React from "react";
-import SkillBadge from "../job/SkillBadge";
+import SkillBadge from "./SkillBadge";
 
 export default function CourseDescription({ desc, skills }) {
   const renderSkillsForCourse = skills.map(({ skillId, skillName, isActive }, index) => (
-    <SkillBadge key={`skill-${skillId}`} skillName={skillName} isActive={isActive}/>
+    <SkillBadge key={`skill-${skillId}`} skillName={skillName} />
   ));
   return (
     <div className='flex flex-row w-full p-4 transition duration-150 ease-in-out'>

--- a/app/src/components/course/CourseDescription.jsx
+++ b/app/src/components/course/CourseDescription.jsx
@@ -1,10 +1,17 @@
 import React from "react";
+import SkillBadge from "../job/SkillBadge";
 
-export default function CourseDescription({ desc }) {
+export default function CourseDescription({ desc, skills }) {
+  const renderSkillsForCourse = skills.map(({ skillId, skillName, isActive }, index) => (
+    <SkillBadge key={`skill-${skillId}`} skillName={skillName} isActive={isActive}/>
+  ));
   return (
     <div className='flex flex-row w-full p-4 transition duration-150 ease-in-out'>
       <div className='flex flex-col w-full'>
         <div className='font-medium text-left'>{desc}</div>
+        {skills.length ? (
+          <div className='flex mt-4'>{renderSkillsForCourse}</div>
+        ) : "No skills offered by course"}
       </div>
     </div>
   );

--- a/app/src/components/course/CourseTile.jsx
+++ b/app/src/components/course/CourseTile.jsx
@@ -9,10 +9,9 @@ function CourseTile({
   courseName,
   courseDesc,
   courseStatus,
-  registrationStatus,
-  completionStatus,
+  skills
 }) {
-  const [isDescOpen, setIsDescOpen] = useState(false);
+  const [isDetailsOpen, setisDetailsOpen] = useState(false);
 
   if (courseStatus !== "Active") {
     return null;
@@ -37,9 +36,9 @@ function CourseTile({
               <button
                 className='w-10 text-right flex justify-end'
                 type='button'
-                onClick={() => setIsDescOpen(!isDescOpen)}
+                onClick={() => setisDetailsOpen(!isDetailsOpen)}
               >
-                {isDescOpen ? (
+                {isDetailsOpen ? (
                   <ArrowDownIcon className='w-5 h-5 transition ease-in-out' aria-hidden='true' />
                 ) : (
                   <ArrowRightIcon className='w-5 h-5 transition ease-in-out' aria-hidden='true' />
@@ -49,7 +48,7 @@ function CourseTile({
           </div>
         </li>
       </ul>
-      {isDescOpen ? <CourseDescription desc={courseDesc} /> : null}
+      {isDetailsOpen ? <CourseDescription desc={courseDesc} skills={skills} /> : null}
     </div>
   );
 }

--- a/app/src/components/course/SkillBadge.jsx
+++ b/app/src/components/course/SkillBadge.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function SkillBadge({ skillName }) {
+  return (
+    <span className='bg-accent4 text-accent1 text-sm font-semibold mr-2 px-2.5 py-0.5 rounded'>
+      {skillName}
+    </span>
+  );
+}

--- a/app/src/components/course/staff/StaffCourse.jsx
+++ b/app/src/components/course/staff/StaffCourse.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { getCourses } from "src/api/course";
+import { toast } from "react-toastify";
+import { getAllCoursesAndActiveSkills } from "src/api/course";
 import { useUserContext } from "src/contexts/UserContext";
 import CourseTile from "../CourseTile";
 
@@ -8,10 +9,13 @@ function StaffCourse() {
   const { currentUserId } = useUserContext();
 
   useEffect(() => {
-    getAllJobs();
+    getAllCourses();
 
-    async function getAllJobs() {
-      const coursesReturnedFromBackend = await getCourses();
+    async function getAllCourses() {
+      const coursesReturnedFromBackend = await getAllCoursesAndActiveSkills();
+      if (coursesReturnedFromBackend.length === 0) {
+        toast.warning("There are no courses to display");
+      }
       setCourses(coursesReturnedFromBackend);
     }
   }, []);
@@ -25,8 +29,7 @@ function StaffCourse() {
       courseName={course.courseName}
       courseDesc={course.courseDesc}
       courseStatus={course.courseStatus}
-      registrationStatus={course.registrationStatus}
-      completionStatus={course.completionStatus}
+      skills={course.skills}
     />
   ));
 

--- a/app/src/components/job/SkillBadge.jsx
+++ b/app/src/components/job/SkillBadge.jsx
@@ -1,9 +1,6 @@
 import React from "react";
 
-export default function SkillBadge({ skillName, isActive }) {
-  if (isActive === 0) {
-    return null;
-  }
+export default function SkillBadge({ skillName }) {
   return (
     <span className='bg-blue-200 text-blue-800 text-xl font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-blue-200 dark:text-blue-800'>
       {skillName}

--- a/app/src/components/job/SkillBadge.jsx
+++ b/app/src/components/job/SkillBadge.jsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-export default function SkillBadge({ skillName }) {
+export default function SkillBadge({ skillName, isActive }) {
+  if (isActive === 0) {
+    return null;
+  }
   return (
     <span className='bg-blue-200 text-blue-800 text-xl font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-blue-200 dark:text-blue-800'>
       {skillName}

--- a/app/src/components/job/staff/StaffJob.jsx
+++ b/app/src/components/job/staff/StaffJob.jsx
@@ -25,7 +25,6 @@ function StaffJob() {
 
     async function getAllJobs() {
       const jobsReturnedFromBackend = await getAllJobsAndSkills(true);
-      // const jobsReturnedFromBackend = [];
       if (jobsReturnedFromBackend.length === 0) {
         toast.warning("There are no jobs to display");
       }

--- a/app/src/components/learningJourney/details/JobAndSkillsContainer.jsx
+++ b/app/src/components/learningJourney/details/JobAndSkillsContainer.jsx
@@ -6,12 +6,18 @@ export default function JobAndSkillsContainer({ LJId, skills, jobName, isJobActi
     <JobSkillBadge skillName={skill.skillName} key={index} />
   ));
 
+  const noActiveSkillsMessage = <div className="text-sm italic text-center">
+    No active skills for this job role
+  </div>;
+
   return (
     <div className='flex flex-col w-48 mt-1 ml-9 lg:col-span-1 col-span-2'>
       <h2 className='mb-1 lg:text-lg font-bold text-center'>Target Job Role:</h2>
       <JobBadge jobName={jobName} isActive={isJobActive} />
 
-      <div className='flex flex-col mt-2 rounded-lg shadow-lg'>{skillList}</div>
+      <div className='flex flex-col mt-2 rounded-lg shadow-lg'>
+        {skillList.length === 0 ? noActiveSkillsMessage : skillList}
+      </div>
     </div>
   );
 }

--- a/app/src/components/learningJourney/details/index.jsx
+++ b/app/src/components/learningJourney/details/index.jsx
@@ -64,8 +64,8 @@ function LearningJourneyDetails() {
       for (let i = 0; i < skillIds.length; i += 1) {
         skillPromises.push(getSkillById(skillIds[i]));
       }
-      const skillsResult = await Promise.all(skillPromises);
-
+      let skillsResult = await Promise.all(skillPromises);
+      skillsResult = skillsResult.filter(skill => skill.isActive);
       setJobName(jobData.jobName);
       setJobDesc(jobData.jobDesc);
       setIsJobActive(jobData.isActive);

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -19,6 +19,12 @@ module.exports = {
         accent2: {
           DEFAULT: "#c2410c",
         },
+        accent3: {
+          DEFAULT: "#de6b07",
+        },
+        accent4: {
+          DEFAULT: "#ff8f2d",
+        },
       },
     },
   },

--- a/backend/app/api/api_v1/endpoints/job.py
+++ b/backend/app/api/api_v1/endpoints/job.py
@@ -50,7 +50,7 @@ def get_all_jobs_and_all_skills(
     LEFT JOIN job_skill ON j.job_ID = job_skill.job_ID
     LEFT JOIN skill as s ON job_skill.Skill_ID = s.Skill_ID{};
     """.format(
-            " WHERE j.is_active = 1" if active_only else ""
+            " AND s.Is_Active=1 WHERE j.is_active = 1" if active_only else ""
         )
     )
     db_cursor_obj = db.execute(sql_query)


### PR DESCRIPTION
# Description
Fixes https://is212g7t5.atlassian.net/browse/G7T5-146

https://user-images.githubusercontent.com/71003267/199282574-dd381c40-9735-4f68-b679-b195ff9f6d34.mp4


List all acceptance criteria of user story and indicate which has been solved previously and which is solved currently
- [x] LJ details page only reflects active skills underneath the corresponding job role (solved)
- [x] If the job role in the LJ no longer has any active skills, display “no active skills for this job role” message (solved)
- [x] Each course’s details in View Courses for Staff should not contain any inactive skills (solved)
- [x] Each job role’s details in View Job Roles for Staff should not contain any inactive skills (solved)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] I have added the corresponding testcases into the [testcase document](https://docs.google.com/spreadsheets/d/1QOyUN_kFN0fddLkjAQz2DK3jou3cWdN9CJsNbl3v0Kg/edit#gid=0)

Please indicate the testcase ID you have added or are using
- [x] G7T5-59-3
- [x] G7T5-59-4
- [x] G7T5-17-1 (modified)
- [x] G7T5-17-2 (modified)

# Checklist:

- [x] I have added the appropriate labels to my PR
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
